### PR TITLE
Tighten exception handling in build_id_messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 arelle/
 
 #Non-library plugin directory
-non_library_plugins/
+non_library_plugins/*.py

--- a/non_library_plugins/README.txt
+++ b/non_library_plugins/README.txt
@@ -1,1 +1,1 @@
-This directory is included and purposefully left empty.  Had to add a file in it so that git checks it out.å
+This directory is included and purposefully left empty.  Had to add a file in it so that git checks it out.

--- a/non_library_plugins/README.txt
+++ b/non_library_plugins/README.txt
@@ -1,0 +1,1 @@
+This directory is included and purposefully left empty.  Had to add a file in it so that git checks it out.å

--- a/utilities/generate_messages_catalog.py
+++ b/utilities/generate_messages_catalog.py
@@ -233,61 +233,64 @@ def _build_id_messages(python_module):
         tree = ast.parse(module_file.read(), filename=python_module)
         callables = filter(_is_callable, ast.walk(tree))
         for item in callables:
+            # imported function could be by id instead of attr
             try:
-                # imported function could be by id instead of attr
                 handler = FUNC_HANDLER.get(
                     item.func.attr, lambda x: ("", 0)
                 )
                 level, args_offset = handler(item)
-
+            except AttributeError:
+                # object has no attribute 'attr'
+                continue
+            try:
                 msgCodeArg = item.args[0 + args_offset]  # str or tuple
-                if isinstance(msgCodeArg, ast.Str):
-                    msgCodes = (msgCodeArg.s,)
+                msg_arg = item.args[1 + args_offset]
+            except IndexError:
+                continue
+            if isinstance(msgCodeArg, ast.Str):
+                msgCodes = (msgCodeArg.s,)
+            else:
+                if any(isinstance(element, (ast.Call, ast.Name))
+                       for element in ast.walk(msgCodeArg)):
+                    msgCodes = ("(dynamic)",)
                 else:
-                    if any(isinstance(element, (ast.Call, ast.Name))
-                           for element in ast.walk(msgCodeArg)):
-                        msgCodes = ("(dynamic)",)
+                    msgCodes = [
+                        element.s for element in ast.walk(msgCodeArg)
+                        if isinstance(element, ast.Str)
+                    ]
+            msg = _get_validation_message(msg_arg)
+            if not msg:
+                continue #not sure what to report
+            keywords = []
+            for keyword in item.keywords:
+                if keyword.arg == 'modelObject':
+                    pass
+                elif keyword.arg == 'messageCodes':
+                    msgCodeArg = keyword.value
+                    if ((any(isinstance(element, (ast.Call, ast.Name))
+                         for element in ast.walk(msgCodeArg)))):
+                        pass  # dynamic
                     else:
                         msgCodes = [
-                            element.s for element in ast.walk(msgCodeArg)
+                            element.s
+                            for element in ast.walk(msgCodeArg)
                             if isinstance(element, ast.Str)
                         ]
-                msg_arg = item.args[1 + args_offset]
-                msg = _get_validation_message(msg_arg)
-                if not msg:
-                    continue #not sure what to report
-                keywords = []
-                for keyword in item.keywords:
-                    if keyword.arg == 'modelObject':
-                        pass
-                    elif keyword.arg == 'messageCodes':
-                        msgCodeArg = keyword.value
-                        if ((any(isinstance(element, (ast.Call, ast.Name))
-                             for element in ast.walk(msgCodeArg)))):
-                            pass  # dynamic
-                        else:
-                            msgCodes = [
-                                element.s
-                                for element in ast.walk(msgCodeArg)
-                                if isinstance(element, ast.Str)
-                            ]
-                    else:
-                        keywords.append(keyword.arg)
-                for msgCode in msgCodes:
-                    id_messages.append(
-                        {
-                            'message_code': msgCode,
-                            'message': entity_encode(msg),
-                            'level': level,
-                            'keyword_arguments': entity_encode(
-                                " ".join(keywords)
-                            ),
-                            'reference_filename': ref_module_name,
-                            'line_number': item.lineno
-                        }
-                    )
-            except (AttributeError, IndexError):
-                pass
+                else:
+                    keywords.append(keyword.arg)
+            for msgCode in msgCodes:
+                id_messages.append(
+                    {
+                        'message_code': msgCode,
+                        'message': entity_encode(msg),
+                        'level': level,
+                        'keyword_arguments': entity_encode(
+                            " ".join(keywords)
+                        ),
+                        'reference_filename': ref_module_name,
+                        'line_number': item.lineno
+                    }
+                )
     return id_messages
 
 


### PR DESCRIPTION
#### Changes:
- Remove function-wide try/catch
- Add more specific try/catch/continues to lines that can throw exceptions
- add readme to non_library_plugins so git checks it out.
- update gitignore.

Unit tests not applicable here - functionally equivalent to before, and not very testable.

Before:
Arelle messages catalog 2.59 secs, 162 formula files, 1287 messages

After:
Arelle messages catalog 1.97 secs, 162 formula files, 1287 messages

Please review: @hefischer  @andrewperkins-wf
