### PR TITLE
Tighten exception handling in build_id_messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 arelle/
 
 #Non-library plugin directory
-non_library_plugins/
+non_library_plugins/*.py

--- a/non_library_plugins/README.txt
+++ b/non_library_plugins/README.txt
@@ -1,1 +1,1 @@
-This directory is included and purposefully left empty.  Had to add a file in it so that git checks it out.å
+This directory is included and purposefully left empty.  Had to add a file in it so that git checks it out.

--- a/non_library_plugins/README.txt
+++ b/non_library_plugins/README.txt
@@ -1,0 +1,1 @@
+This directory is included and purposefully left empty.  Had to add a file in it so that git checks it out.å

--- a/test/utilities/test_generate_messages_catalog.py
+++ b/test/utilities/test_generate_messages_catalog.py
@@ -112,3 +112,35 @@ class TestUtilties(unittest.TestCase):
         mock_arg = mock.Mock()
         msg_arg.args = [mock_arg]
         self.assertFalse(generate_messages_catalog._is_translatable(msg_arg))
+
+    @mock.patch('ast.walk')
+    def test_get_message_codes_good(self, mock_walk):
+        """Checks for proper returns for the three accepted input types"""
+        my_msg_arg = mock.Mock(spec=ast.Str, s='foo')
+        codes = generate_messages_catalog._get_message_codes(my_msg_arg)
+        self.assertEqual(codes, ('foo',))
+
+        my_msg_arg = None
+        mock_walk.return_value = [
+            mock.Mock(spec=ast.Str, s='foo'),
+            mock.Mock(spec=ast.Call),
+            mock.Mock(spec=ast.Name)
+        ]
+        codes = generate_messages_catalog._get_message_codes(my_msg_arg)
+        self.assertEqual(codes, ('(dynamic)',))
+
+        mock_walk.return_value = [
+            mock.Mock(spec=ast.Str, s='foo'), mock.Mock(spec=ast.Str, s='bar')
+        ]
+        codes = generate_messages_catalog._get_message_codes(my_msg_arg)
+        self.assertEqual(codes, ['foo', 'bar'])
+
+    @mock.patch('ast.walk')
+    def test_get_message_codes_bad(self, mock_walk):
+        """Checks for proper returns of nonsupported input"""
+        my_msg_arg = mock.Mock(spec=ast.Call)
+        mock_walk.return_value = [
+            mock.Mock(spec=ast.Num), mock.Mock(spec=ast.Subscript)
+        ]
+        codes = generate_messages_catalog._get_message_codes(my_msg_arg)
+        self.assertEqual(codes, [])

--- a/utilities/generate_messages_catalog.py
+++ b/utilities/generate_messages_catalog.py
@@ -288,7 +288,7 @@ def _get_message_codes(msg_code_arg):
     :param msg_code_arg: the current arg to pull msgCodes from
     :type msg_code_arg: :class:`~ast.AST`
     :return: the correct message code to use
-    :rtype: str
+    :rtype: tuple
     """
     msg_codes = None
     if isinstance(msg_code_arg, ast.Str):
@@ -298,10 +298,10 @@ def _get_message_codes(msg_code_arg):
                for element in ast.walk(msg_code_arg)):
             msg_codes = ('(dynamic)',)
         else:
-            msg_codes = [
+            msg_codes = tuple([
                 element.s for element in ast.walk(msg_code_arg)
                 if isinstance(element, ast.Str)
-            ]
+            ])
     return msg_codes
 
 

--- a/utilities/generate_messages_catalog.py
+++ b/utilities/generate_messages_catalog.py
@@ -296,7 +296,7 @@ def _get_message_codes(msg_code_arg):
     else:
         if any(isinstance(element, (ast.Call, ast.Name))
                for element in ast.walk(msg_code_arg)):
-            msg_codes = ("(dynamic)",)
+            msg_codes = ('(dynamic)',)
         else:
             msg_codes = [
                 element.s for element in ast.walk(msg_code_arg)

--- a/utilities/generate_messages_catalog.py
+++ b/utilities/generate_messages_catalog.py
@@ -241,21 +241,11 @@ def _build_id_messages(python_module):
                 level, args_offset = handler(item)
 
                 msgCodeArg = item.args[0 + args_offset]  # str or tuple
-                if isinstance(msgCodeArg, ast.Str):
-                    msgCodes = (msgCodeArg.s,)
-                else:
-                    if any(isinstance(element, (ast.Call, ast.Name))
-                           for element in ast.walk(msgCodeArg)):
-                        msgCodes = ("(dynamic)",)
-                    else:
-                        msgCodes = [
-                            element.s for element in ast.walk(msgCodeArg)
-                            if isinstance(element, ast.Str)
-                        ]
                 msg_arg = item.args[1 + args_offset]
                 msg = _get_validation_message(msg_arg)
                 if not msg:
-                    continue #not sure what to report
+                    continue  # not sure what to report
+                msgCodes = _get_message_codes(msgCodeArg)
                 keywords = []
                 for keyword in item.keywords:
                     if keyword.arg == 'modelObject':
@@ -289,6 +279,30 @@ def _build_id_messages(python_module):
             except (AttributeError, IndexError):
                 pass
     return id_messages
+
+
+def _get_message_codes(msg_code_arg):
+    """
+    Get the correct message codes based on instance type of msgCodeArg
+
+    :param msg_code_arg: the current arg to pull msgCodes from
+    :type msg_code_arg: :class:`~ast.AST`
+    :return: the correct message code to use
+    :rtype: str
+    """
+    msg_codes = None
+    if isinstance(msg_code_arg, ast.Str):
+        msg_codes = (msg_code_arg.s,)
+    else:
+        if any(isinstance(element, (ast.Call, ast.Name))
+               for element in ast.walk(msg_code_arg)):
+            msg_codes = ("(dynamic)",)
+        else:
+            msg_codes = [
+                element.s for element in ast.walk(msg_code_arg)
+                if isinstance(element, ast.Str)
+            ]
+    return msg_codes
 
 
 def _get_validation_message(msg_arg):


### PR DESCRIPTION
#### Changes:
- Remove function-wide try/catch
- Add more specific try/catch/continues to lines that can throw exceptions
- add readme to non_library_plugins so git checks it out.
- update gitignore.

Unit tests not applicable here - functionally equivalent to before, and not very testable.

This is based on @brianmyers-wf 's 2883 branch.  

Before:
Arelle messages catalog 2.59 secs, 162 formula files, 1287 messages

After:
Arelle messages catalog 1.97 secs, 162 formula files, 1287 messages

Please review: @hefischer  @andrewperkins-wf
